### PR TITLE
Update to existing version of detekt-gradle-plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     implementation "com.android.tools.build:gradle:3.3.2"
 
     implementation "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.7"
-    implementation "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.0.0-RC14"
+    implementation "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.0.1"
 }
 
 compileKotlin {


### PR DESCRIPTION
Old versions of ‘detekt’ have been removed from the Maven repository and cannot be resolved.
This makes android-analyzer fail compile time in a gradle project. 
This commit updates the version of 'detekt' to the latest stable. It works without any issues when analyzing my android project. 